### PR TITLE
17 hotfix button

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -4,6 +4,7 @@
   min-width: 5rem;
   padding: 0.625rem 1.25rem;
   border-radius: 0.5rem;
+  margin: 0.5rem;
 
   &--yellow {
     background-color: $clr-accent-yellow;
@@ -32,6 +33,15 @@
     background-color: $clr-white;
     border: 0.12rem solid $clr-accent-purple;
     color: $clr-accent-purple;
+  }
+
+  &--large {
+    width: 90%;
+    padding: 0.9rem 1.25rem;
+  }
+
+  &--small {
+    width: 40%;
   }
 
   &:hover {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,17 +1,22 @@
 import "./Button.scss";
+import { Link } from "react-router-dom";
 
 type ButtonProps = {
   label: string;
   variant: "yellow" | "grey" | "red" | "purple" | "red-alt";
   onClick: () => void;
+  size?: "large" | "small";
+  path?: string;
 };
 
-const Button = ({ label, variant, onClick }: ButtonProps) => {
-  const className = `button button--${variant}`;
+const Button = ({ label, variant, onClick, size, path }: ButtonProps) => {
+  const className = `button button--${variant} button--${size || "small"}`;
   return (
-    <button className={className} onClick={onClick}>
-      {label}
-    </button>
+    <Link to={path || "#"} >
+      <button className={className} onClick={onClick}>
+        {label}
+      </button>
+    </Link>
   );
 };
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 type ButtonProps = {
   label: string;
   variant: "yellow" | "grey" | "red" | "purple" | "red-alt";
-  onClick: () => void;
+  onClick?: () => void;
   size?: "large" | "small";
   path?: string;
 };
@@ -13,7 +13,7 @@ const Button = ({ label, variant, onClick, size, path }: ButtonProps) => {
   const className = `button button--${variant} button--${size || "small"}`;
   return (
     <Link to={path || "#"} >
-      <button className={className} onClick={onClick}>
+      <button className={className} onClick={onClick?() => onClick(): undefined}>
         {label}
       </button>
     </Link>


### PR DESCRIPTION
Fixed size requirements for buttons by adding a large and a short option, and added 'size' as an optional ButtonProp. 

Added 'path' as an optional prop to ButtonProps so it can reroute the page when clicked or perform a function / specific task when clicked.

Edited 'onClick' prop to be optional in case it is not needed - adding additional flexibility. 